### PR TITLE
v1.2.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,6 +2,6 @@ package nrelay
 
 const (
   AppName string = "nats-relay"
-  Version string = "1.1.0"
+  Version string = "1.2.0"
   UA      string = AppName + "/" + Version
 )


### PR DESCRIPTION
interface changed:
- Fix to start even if secondary nats is not specified(e.g. `secondary: ""` in relay.yaml)